### PR TITLE
Call send_event rather than Object#send

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ This cookbook has been verified to work on the following platforms:
 
 ## Usage
 
-All you need to do is set the `node['sentry']['dsn']` value and add
+All you need to do is set the `node['sentry']['options']['dsn']` value and add
 the default recipe of this cookbook to your run-list. You can do this
 from a wrapper cookbook recipe:
 
 ``` ruby
-node.default['sentry']['dsn'] = 'https://xxxx:yyyy@sentry.corporate.com/1'
+node.default['sentry']['options']['dsn'] = 'https://xxxx:yyyy@sentry.corporate.com/1'
 include_recipe 'chef-sentry-handler::default'
 ```
 

--- a/files/default/sentry.rb
+++ b/files/default/sentry.rb
@@ -59,6 +59,6 @@ class Chef::Handler::Sentry < Chef::Handler
       h[:policy_group] = node.policy_group if node.policy_group
       h[:policy_revision] = node['policy_revision'] if node['policy_revision']
     end
-    Raven.send(event)
+    Raven.send_event(event)
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Installs and configures a Chef handler for sending errors to Sentry.'
 long_description 'Installs and configures a Chef handler for sending errors to Sentry.'
-version '2.0.0'
+version '2.1.0'
 chef_version '>= 12.1'
 
 depends 'chef_handler', '~> 2.0'


### PR DESCRIPTION
Currently, the Chef handler fails to report errors to Sentry. The [call to`Raven#send`](https://github.com/johnbellone/chef-sentry-handler/blob/a2a80040b8739aec4be880dcc1b2316b84e01d81/files/default/sentry.rb#L62) should be to `Raven#send_event`, instead of `Object#send`.

The PR also has some small changes to the `README.md` examples.