### PR TITLE
Convert the timestamp to ISO8601 before sending to Sentry

### DIFF
--- a/files/default/sentry.rb
+++ b/files/default/sentry.rb
@@ -52,7 +52,8 @@ class Chef::Handler::Sentry < Chef::Handler
             end
     event.server_name = node.name
     event.release = node['policy_revision'] if node['policy_revision']
-    event.timestamp = run_status.start_time
+    # ISO 8601, no timestamp
+    event.timestamp = run_status.start_time.iso8601.gsub(/Z$/, '')
     event.time_spent = run_status.elapsed_time
     event.extra = { run_id: run_status.run_id }.tap do |h|
       h[:policy_name] = node.policy_name if node.policy_name


### PR DESCRIPTION
Sentry requires the timestamp as ISO8061 without a timezone (https://docs.sentry.io/clientdev/attributes/)

The current code in master results in the following errors in Sentry:

```
There was 1 error encountered while processing this event

    Discarded invalid value for parameter 'timestamp' Collapse

    {
      "name": "timestamp",
      "value": "2017-07-29 09:44:07 UTC"
    }
```

This PR transforms the timestamp into the correct format