### PR TITLE
Update to latest sentry-raven (2.7.2)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,4 +19,4 @@ default['sentry']['options']['dsn'] = nil
 default['sentry']['options']['ssl_verify'] = true
 default['sentry']['options']['environment'] = node.chef_environment
 
-default['sentry']['gem_version'] = '2.0.2'
+default['sentry']['gem_version'] = '2.7.2'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Installs and configures a Chef handler for sending errors to Sentry.'
 long_description 'Installs and configures a Chef handler for sending errors to Sentry.'
-version '2.1.0'
+version '2.2.0'
 chef_version '>= 12.1'
 
 depends 'chef_handler', '~> 2.0'


### PR DESCRIPTION
The last time it was updated was in 2015; that version is not compatible with the newer ChefDK. This  version is.